### PR TITLE
Queries on endpoint /trips

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ If you're gonna develop:
 
 This will watch for changes and keep it open for you.
 
+To enter some test data into your database, run `npm run load`.
+
 ## Tests
 
 ### Single run

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start:test": "babel-node test/test",
     "test": "npm run lint && npm run tests",
     "tests": "NODE_ENV=test nyc ava --serial",
-    "test:watch": "NODE_ENV=test ava --serial --watch"
+    "test:watch": "NODE_ENV=test ava --serial --watch",
+    "load": "babel-node test/load.js"
   },
   "ava": {
     "require": "babel-core/register",

--- a/src/components/errors.js
+++ b/src/components/errors.js
@@ -105,15 +105,15 @@ export class AuthenticationError extends Error {
 }
 
 /**
- * InvalidQueryError - Returns a 401 Given query was invalid.
- * indicating that the query the user gave was invalid.
+ * UriValidationError - Returns a 400 Invalid URI.
+ * indicating that the URI the user gave was invalid.
  *
  * @return {Object}  - Error object
  */
-export class InvalidQueryError extends Error {
-    name = 'InvalidQueryError';
+export class UriValidationError extends Error {
+    name = 'UriValidationError';
     status = 400;
-    constructor(message = 'Given query was invalid.') {
+    constructor(message = 'Invalid URI.') {
         super(message);
         this.message = message;
     }

--- a/src/components/errors.js
+++ b/src/components/errors.js
@@ -90,7 +90,7 @@ export class ResourceNotFoundError extends Error {
 
 /**
  * AuthenticationError - Returns a 401 You need to authenicate to access this resource,
- * implying that the user does not have enough premissions to complete this request.
+ * indicating that the user does not have enough premissions to complete this request.
  *
  * @param  {String} message - A message sent to the user why he/she is not authenticated
  * @return {Object}  - Error object
@@ -99,6 +99,21 @@ export class AuthenticationError extends Error {
     name = 'AuthenticationError';
     status = 401;
     constructor(message = 'You need to authenicate to access this resource') {
+        super(message);
+        this.message = message;
+    }
+}
+
+/**
+ * InvalidQueryError - Returns a 401 Given query was invalid.
+ * indicating that the query the user gave was invalid.
+ *
+ * @return {Object}  - Error object
+ */
+export class InvalidQueryError extends Error {
+    name = 'InvalidQueryError';
+    status = 400;
+    constructor(message = 'Given query was invalid.') {
         super(message);
         this.message = message;
     }

--- a/src/components/queryValidator.js
+++ b/src/components/queryValidator.js
@@ -1,0 +1,12 @@
+
+export function validateQuery(query, allowedQueryParams) {
+    const keys = Object.keys(query);
+    let isValid = true;
+    for (let i = 0; i < keys.length; i++) {
+        if (allowedQueryParams.indexOf(keys[i]) === -1) {
+            isValid = false;
+            break;
+        }
+    }
+    return isValid;
+}

--- a/src/components/queryValidator.js
+++ b/src/components/queryValidator.js
@@ -1,4 +1,16 @@
+/**
+ * Generic validation of query objects
+ * @module components/queryValidator
+ */
 
+/**
+ * validateQuery - Catches all upstream errors and returns them to the requester.
+ *
+ * @param  {Object} query - Express req.query object
+ * @param  {Array} allowedQueryParams - List of names of model properties that
+ * are allowed to be queried on
+ * @return {Boolean}  - If the query is valid or not
+ */
 export function validateQuery(query, allowedQueryParams) {
     const keys = Object.keys(query);
     let isValid = true;

--- a/src/components/queryValidator.js
+++ b/src/components/queryValidator.js
@@ -3,6 +3,8 @@
  * @module components/queryValidator
  */
 
+import _ from 'lodash';
+
 /**
  * validateQuery - Catches all upstream errors and returns them to the requester.
  *
@@ -12,13 +14,9 @@
  * @return {Boolean}  - If the query is valid or not
  */
 export function validateQuery(query, allowedQueryParams) {
-    const keys = Object.keys(query);
     let isValid = true;
-    for (let i = 0; i < keys.length; i++) {
-        if (allowedQueryParams.indexOf(keys[i]) === -1) {
-            isValid = false;
-            break;
-        }
-    }
+    _.mapKeys(query, (value, key) => {
+        if (allowedQueryParams.indexOf(key) === -1) isValid = false;
+    });
     return isValid;
 }

--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -4,10 +4,14 @@
  */
 import Sequelize from 'sequelize';
 import db from '../models';
-import { ResourceNotFoundError, ValidationError, DatabaseError } from '../components/errors';
+import { ResourceNotFoundError,
+        ValidationError,
+        DatabaseError,
+        InvalidQueryError } from '../components/errors';
+
 
 /**
- * list - List all trips in the database
+ * list - List trips that qualify query
  *
  * @function list
  * @memberof  module:controllers/trip
@@ -16,6 +20,9 @@ import { ResourceNotFoundError, ValidationError, DatabaseError } from '../compon
  * @param  {Function} next Express next middleware function
  */
 export function list(req, res, next) {
+    if (!db.Trip.validateQuery(req.query)) {
+        throw new InvalidQueryError();
+    }
     db.Trip.findAll({
         where: req.query
     })

--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -16,9 +16,11 @@ import { ResourceNotFoundError, ValidationError, DatabaseError } from '../compon
  * @param  {Function} next Express next middleware function
  */
 export function list(req, res, next) {
-    db.Trip.findAll()
-        .then(res.json.bind(res))
-        .catch(next);
+    db.Trip.findAll({
+        where: req.query
+    })
+    .then(res.json.bind(res))
+    .catch(next);
 }
 
 /**

--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -4,10 +4,7 @@
  */
 import Sequelize from 'sequelize';
 import db from '../models';
-import { ResourceNotFoundError,
-        ValidationError,
-        DatabaseError,
-        InvalidQueryError } from '../components/errors';
+import * as errors from '../components/errors';
 
 
 /**
@@ -21,7 +18,7 @@ import { ResourceNotFoundError,
  */
 export function list(req, res, next) {
     if (!db.Trip.validateQuery(req.query)) {
-        throw new InvalidQueryError();
+        throw new errors.InvalidQueryError();
     }
     db.Trip.findAll({
         where: req.query,
@@ -51,7 +48,7 @@ export function create(req, res, next) {
     db.Trip.create(req.body)
         .then(savedObj => res.status(201).json(savedObj))
         .catch(Sequelize.ValidationError, err => {
-            throw new ValidationError(err);
+            throw new errors.ValidationError(err);
         })
         .catch(next);
 }
@@ -72,7 +69,7 @@ export function destroy(req, res, next) {
         }
     })
     .then(count => {
-        if (!count) throw new ResourceNotFoundError('trip');
+        if (!count) throw new errors.ResourceNotFoundError('trip');
         res.sendStatus(200);
     })
     .catch(next);
@@ -94,15 +91,15 @@ export function update(req, res, next) {
         }
     })
     .then(trip => {
-        if (!trip) throw new ResourceNotFoundError('trip');
+        if (!trip) throw new errors.ResourceNotFoundError('trip');
         return trip.update(req.body);
     })
     .then(() => res.sendStatus(204))
     .catch(Sequelize.ValidationError, err => {
-        throw new ValidationError(err);
+        throw new errors.ValidationError(err);
     })
     .catch(Sequelize.DatabaseError, err => {
-        throw new DatabaseError(err);
+        throw new errors.DatabaseError(err);
     })
     .catch(next);
 }

--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -24,7 +24,15 @@ export function list(req, res, next) {
         throw new InvalidQueryError();
     }
     db.Trip.findAll({
-        where: req.query
+        where: req.query,
+        include: [{
+            model: db.User,
+            attributes: {
+                exclude: ['hash']
+            }
+        }, {
+            model: db.Destination
+        }]
     })
     .then(res.json.bind(res))
     .catch(next);

--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -18,7 +18,7 @@ import * as errors from '../components/errors';
  */
 export function list(req, res, next) {
     if (!db.Trip.validateQuery(req.query)) {
-        throw new errors.InvalidQueryError();
+        throw new errors.UriValidationError();
     }
     db.Trip.findAll({
         where: req.query,

--- a/src/models/trip.model.js
+++ b/src/models/trip.model.js
@@ -49,7 +49,7 @@ export default function (sequelize, DataTypes) {
         },
         hooks: {
             beforeUpdate: [
-                (trip) => {
+                trip => {
                     if (trip.changed('status') && trip.status === TRIP_STATUSES.ACCEPTED) {
                         return trip.acceptUser();
                     }

--- a/src/models/trip.model.js
+++ b/src/models/trip.model.js
@@ -1,7 +1,10 @@
 import _ from 'lodash';
 import Promise from 'bluebird';
+import { validateQuery } from '../components/queryValidator';
 import { TRIP_STATUSES } from '../components/constants';
 import db from './';
+
+const ALLOWED_QUERY_PARAMS = ['destinationId', 'userId', 'status'];
 
 export default function (sequelize, DataTypes) {
     const Trip = sequelize.define('trip', {
@@ -39,6 +42,9 @@ export default function (sequelize, DataTypes) {
                         allowNull: false
                     }
                 });
+            },
+            validateQuery(query) {
+                return validateQuery(query, ALLOWED_QUERY_PARAMS);
             }
         },
         hooks: {

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -90,7 +90,7 @@ export default function (sequelize, DataTypes) {
         },
         hooks: {
             beforeUpdate: [
-                (user) => {
+                user => {
                     if (!user.changed('password')) return Promise.resolve();
                     return bcrypt.genSaltAsync()
                         .then(salt => bcrypt.hashAsync(user.get('password'), salt))

--- a/test/api/trips.test.js
+++ b/test/api/trips.test.js
@@ -49,7 +49,7 @@ describe.serial('Trip API', it => {
         t.is(response.length, tripObjects.length);
     });
 
-    it('should be able to get all trips of a spcecific destinationId', async t => {
+    it('should be able to get all trips of a specific destinationId', async t => {
         const response = await request(app)
             .get(`${URI}?destinationId=${tripObjects[0].destinationId}`)
             .expect(200)
@@ -57,7 +57,7 @@ describe.serial('Trip API', it => {
         t.is(response.length, 1);
     });
 
-    it('should be able to get trips of a spcecific userId', async t => {
+    it('should be able to get trips of a specific userId', async t => {
         const response = await request(app)
             .get(`${URI}?userId=${tripObjects[0].userId}`)
             .expect(200)
@@ -66,7 +66,7 @@ describe.serial('Trip API', it => {
     });
 
 
-    it('should be able to get all trips of a spcecific status', async t => {
+    it('should be able to get all trips of a specific status', async t => {
         const fixture = tripObjects[0];
         const response = await request(app)
             .get(`${URI}?status=${fixture.status}`)
@@ -75,7 +75,7 @@ describe.serial('Trip API', it => {
         t.is(response.length, 1);
     });
 
-    it('should be able to get trips of a spcecific userId and destinationId', async t => {
+    it('should be able to get trips of a specific userId and destinationId', async t => {
         const fixture = tripObjects[0];
         const response = await request(app)
             .get(`${URI}?userId=${fixture.userId}&destinationId=${fixture.destinationId}`)
@@ -84,7 +84,7 @@ describe.serial('Trip API', it => {
         t.is(response.length, 1);
     });
 
-    it('should be able to get trips of a spcecific userId, destinationId and status', async t => {
+    it('should be able to get trips of a specific userId, destinationId and status', async t => {
         const fixture = tripObjects[0];
         const response = await request(app)
             .get(`${URI}?userId=${fixture.userId}

--- a/test/api/trips.test.js
+++ b/test/api/trips.test.js
@@ -49,6 +49,101 @@ describe.serial('Trip API', it => {
         t.is(response.length, tripObjects.length);
     });
 
+    it('should be able to get all trips of a spcecific destinationId', async t => {
+        const response = await request(app)
+            .get(`${URI}?destinationId=${tripObjects[0].destinationId}`)
+            .expect(200)
+            .then(res => res.body);
+        t.is(response.length, 1);
+    });
+
+    it('should be able to get trips of a spcecific userId', async t => {
+        const response = await request(app)
+            .get(`${URI}?userId=${tripObjects[0].userId}`)
+            .expect(200)
+            .then(res => res.body);
+        t.is(response.length, 2);
+    });
+
+
+    it('should be able to get all trips of a spcecific status', async t => {
+        const fixture = tripObjects[0];
+        const response = await request(app)
+            .get(`${URI}?status=${fixture.status}`)
+            .expect(200)
+            .then(res => res.body);
+        t.is(response.length, 1);
+    });
+
+    it('should be able to get trips of a spcecific userId and destinationId', async t => {
+        const fixture = tripObjects[0];
+        const response = await request(app)
+            .get(`${URI}?userId=${fixture.userId}&destinationId=${fixture.destinationId}`)
+            .expect(200)
+            .then(res => res.body);
+        t.is(response.length, 1);
+    });
+
+    it('should be able to get trips of a spcecific userId, destinationId and status', async t => {
+        const fixture = tripObjects[0];
+        const response = await request(app)
+            .get(`${URI}?userId=${fixture.userId}
+                        &destinationId=${fixture.destinationId}
+                        &status=${fixture.status}`)
+            .expect(200)
+            .then(res => res.body);
+        t.is(response.length, 1);
+    });
+
+    it('should be not be able to query on startDate', async t => {
+        const fixture = tripObjects[0];
+        const response = await request(app)
+            .get(`${URI}?startDate=${fixture.startDate}`)
+            .expect(400)
+            .then(res => res.body);
+        t.is(response.name, 'InvalidQueryError');
+        t.is(response.message, 'Given query was invalid.');
+    });
+
+    it('should be not be able to query on endDate', async t => {
+        const fixture = tripObjects[0];
+        const response = await request(app)
+            .get(`${URI}?endDate=${fixture.endDate}`)
+            .expect(400)
+            .then(res => res.body);
+        t.is(response.name, 'InvalidQueryError');
+        t.is(response.message, 'Given query was invalid.');
+    });
+
+    it('should be not be able to query on wishStartDate', async t => {
+        const fixture = tripObjects[0];
+        const response = await request(app)
+            .get(`${URI}?wishStartDate=${fixture.wishStartDate}`)
+            .expect(400)
+            .then(res => res.body);
+        t.is(response.name, 'InvalidQueryError');
+        t.is(response.message, 'Given query was invalid.');
+    });
+
+    it('should be not be able to query on wishEndDate', async t => {
+        const fixture = tripObjects[0];
+        const response = await request(app)
+            .get(`${URI}?wishEndDate=${fixture.wishEndDate}`)
+            .expect(400)
+            .then(res => res.body);
+        t.is(response.name, 'InvalidQueryError');
+        t.is(response.message, 'Given query was invalid.');
+    });
+
+    it('should reject queries on non-existing model properties', async t => {
+        const response = await request(app)
+            .get(`${URI}?topkek=someValue&capra=summmer`)
+            .expect(400)
+            .then(res => res.body);
+        t.is(response.name, 'InvalidQueryError');
+        t.is(response.message, 'Given query was invalid.');
+    });
+
     it('should be able to create a new trip ', async t => {
         const response = await request(app)
             .post(URI)

--- a/test/api/trips.test.js
+++ b/test/api/trips.test.js
@@ -101,8 +101,8 @@ describe.serial('Trip API', it => {
             .get(`${URI}?startDate=${fixture.startDate}`)
             .expect(400)
             .then(res => res.body);
-        t.is(response.name, 'InvalidQueryError');
-        t.is(response.message, 'Given query was invalid.');
+        t.is(response.name, 'UriValidationError');
+        t.is(response.message, 'Invalid URI.');
     });
 
     it('should be not be able to query on endDate', async t => {
@@ -111,8 +111,8 @@ describe.serial('Trip API', it => {
             .get(`${URI}?endDate=${fixture.endDate}`)
             .expect(400)
             .then(res => res.body);
-        t.is(response.name, 'InvalidQueryError');
-        t.is(response.message, 'Given query was invalid.');
+        t.is(response.name, 'UriValidationError');
+        t.is(response.message, 'Invalid URI.');
     });
 
     it('should be not be able to query on wishStartDate', async t => {
@@ -121,8 +121,8 @@ describe.serial('Trip API', it => {
             .get(`${URI}?wishStartDate=${fixture.wishStartDate}`)
             .expect(400)
             .then(res => res.body);
-        t.is(response.name, 'InvalidQueryError');
-        t.is(response.message, 'Given query was invalid.');
+        t.is(response.name, 'UriValidationError');
+        t.is(response.message, 'Invalid URI.');
     });
 
     it('should be not be able to query on wishEndDate', async t => {
@@ -131,8 +131,8 @@ describe.serial('Trip API', it => {
             .get(`${URI}?wishEndDate=${fixture.wishEndDate}`)
             .expect(400)
             .then(res => res.body);
-        t.is(response.name, 'InvalidQueryError');
-        t.is(response.message, 'Given query was invalid.');
+        t.is(response.name, 'UriValidationError');
+        t.is(response.message, 'Invalid URI.');
     });
 
     it('should reject queries on non-existing model properties', async t => {
@@ -140,8 +140,8 @@ describe.serial('Trip API', it => {
             .get(`${URI}?topkek=someValue&capra=summmer`)
             .expect(400)
             .then(res => res.body);
-        t.is(response.name, 'InvalidQueryError');
-        t.is(response.message, 'Given query was invalid.');
+        t.is(response.name, 'UriValidationError');
+        t.is(response.message, 'Invalid URI.');
     });
 
     it('should be able to create a new trip ', async t => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,7 +8,8 @@ import config from '../src/config';
 export function loadFixtures(fixtures) {
     const f = fixtures || [
         'users',
-        'destinations'
+        'destinations',
+        'trips'
     ];
     const fixturePaths = f.map(file => `${path.resolve(__dirname)}/fixtures/${file}.json`);
     return syncDB({ force: true })

--- a/test/load.js
+++ b/test/load.js
@@ -1,0 +1,3 @@
+import { loadFixtures } from './helpers';
+
+loadFixtures();


### PR DESCRIPTION
Summary of changes:
- Makes it possible to query trips on `destinationId`, `status` and `userId`
- Includes user and destination-objects as part of the trip object when getting trips
- Added tests to trips endpoint
- Small refactor in model
- Makes it possible to add test data to your local database with `npm run load`

Updated documentation for API is found [here](https://confluence.capraconsulting.no/display/DIH/REST+API)

See [DIH-156](https://jira.capraconsulting.no/browse/DIH-156)
