### PR TITLE
[Doppins] Upgrade dependency eslint to ^3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "^3.0.0",
+    "eslint": "^3.0.1",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "^2.12.0",
+    "eslint": "^3.0.0",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `^2.12.0` to `^3.0.0`
