### PR TITLE
[Doppins] Upgrade dependency eslint-config-airbnb-base to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
     "eslint": "^2.12.0",
-    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-config-airbnb-base": "^4.0.0",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",
     "jsdoc": "^3.4.0",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-config-airbnb-base`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-config-airbnb-base from `^3.0.1` to `^4.0.0`
