### PR TITLE
Add migration for new status enums

### DIFF
--- a/src/db-helpers/migrations/08072016.00.trip.migration.js
+++ b/src/db-helpers/migrations/08072016.00.trip.migration.js
@@ -1,0 +1,14 @@
+
+module.exports = {
+
+    up(queryInterface) {
+        return queryInterface.sequelize.query("ALTER TYPE enum_trips_status ADD VALUE 'LEFT'")
+        .then(() =>
+            queryInterface.sequelize.query("ALTER TYPE enum_trips_status ADD VALUE 'PRESENT'"
+        ));
+    },
+
+    down() {
+        return; // @ TODO SQL for teardown, Rebuild table with old ENUMs
+    }
+};


### PR DESCRIPTION
Just adds new enums to database schema.

Rollback is not yet enabled due to the following reasons:
- Not needed as of now, as there are no users of our environments
- You cannot simply remove enum values with Postgres, so it has to rebuild the table with a new set of enum values. This has to be done with SQL. The values in the table with the new statuses must have a suitable rollback value (i.e. LEFT => CLOSED, and PRSENT => ACTIVE).

See [DIH-193](https://jira.capraconsulting.no/browse/DIH-193)
