### PR TITLE
Allow administators to sepecify one user for a new trip

### DIFF
--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -67,9 +67,15 @@ export function retrieve(req, res, next) {
  * @param  {Function} next Express next middleware function
  */
 export function create(req, res, next) {
+    let userId;
+    if (req.user.role === 'ADMIN' && req.body.userId) {
+        userId = req.body.userId;
+    } else {
+        userId = req.user.id;
+    }
     db.Trip.create({
         ...req.body,
-        userId: req.user.id
+        userId
     })
     .then(savedObj => res.status(201).json(savedObj))
     .catch(Sequelize.ValidationError, err => {

--- a/test/api/trips.test.js
+++ b/test/api/trips.test.js
@@ -170,6 +170,19 @@ describe.serial('Trip API', it => {
         t.is(response.body.status, mockTrip.status);
     });
 
+    it('should be able to create a new trip with other user when admin ', async t => {
+        const response = await request(app)
+            .post(URI)
+            .send({
+                ...mockTrip,
+                userId: userObjects[0].id
+            })
+            .set('Authorization', `Bearer ${createValidJWT(userObjects[1])}`)
+            .expect(201)
+            .then(res => res);
+        t.is(response.body.userId, userObjects[0].id);
+    });
+
     it('should not be able to create a new trip with missing status field', async () => {
         const mockWithEmptyStatus = mockTrip;
         delete mockWithEmptyStatus.status;


### PR DESCRIPTION
This PR will update the API to allow the progress with DIH-206 to continue. Before, the create trip end-point was restricted to the currently logged in user. This PR will allow administrators to specify a user for a new trip.
