### PR TITLE
Migration that adds mailTemplates to old destinations

### DIFF
--- a/src/db-helpers/index.js
+++ b/src/db-helpers/index.js
@@ -33,6 +33,13 @@ export function migrateDB() {
         .up();
 }
 
+/**
+ * createDefaultAdmin - Creates a default user with role ADMIN
+ *
+ * @function createDefaultAdmin
+ * @memberof  module:db-helpers/createDefaultAdmin
+ * @return {SequlizeInstance} user The default user with role ADMIN
+ */
 export function createDefaultAdmin(password) {
     return db.User.create({
         firstname: 'Admin',
@@ -42,5 +49,6 @@ export function createDefaultAdmin(password) {
     })
     .then(user => {
         user.updatePassword(password);
-    });
+    })
+    .catch(db.sequelize.UniqueConstraintError); // In case it's already added
 }

--- a/src/db-helpers/migrate.js
+++ b/src/db-helpers/migrate.js
@@ -3,6 +3,7 @@
  * @module db-helpers/migrate
  */
 import Umzug from 'umzug';
+import db from '../models';
 
 /**
  * default - exports default function
@@ -25,6 +26,7 @@ export default function (sequlizeInstance) {
             params: [
                 sequlizeInstance.getQueryInterface(),
                 sequlizeInstance.constructor,
+                db,
                 () => {
                     throw new Error(`Migration tried to use old style "done" callback.
                     Please upgrade to "umzug" and return a promise instead.`);

--- a/src/db-helpers/migrations/25072016.01.destination.migration.js
+++ b/src/db-helpers/migrations/25072016.01.destination.migration.js
@@ -1,0 +1,37 @@
+import _ from 'lodash';
+import Promise from 'bluebird';
+
+module.exports = {
+    up(migration, DataTypes, db) {
+        db.Destination.findAll({
+            where: {
+                pendingStatusMailTemplateId: null,
+                acceptedStatusMailTemplateId: null,
+                rejectedStatusMailTemplateId: null
+            }
+        }).then(destinations => {
+            _.forEach(destinations, (d) => {
+                const destination = d;
+                Promise.all([
+                    db.MailTemplate.create(),
+                    db.MailTemplate.create(),
+                    db.MailTemplate.create()
+                ]).spread((mt1, mt2, mt3) => {
+                    destination.pendingStatusMailTemplateId = mt1.id;
+                    destination.acceptedStatusMailTemplateId = mt2.id;
+                    destination.rejectedStatusMailTemplateId = mt3.id;
+                })
+                .then(() => destination.save());
+            });
+        });
+    },
+
+    down(migration) {
+        return [
+            migration.removeColumn('destinations', 'pendingStatusMailTemplateId'),
+            migration.removeColumn('destinations', 'acceptedStatusMailTemplateId'),
+            migration.removeColumn('destinations', 'rejectedStatusMailTemplateId')
+        ];
+    }
+
+};

--- a/src/db-helpers/migrations/25072016.01.destination.migration.js
+++ b/src/db-helpers/migrations/25072016.01.destination.migration.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import Promise from 'bluebird';
 
 module.exports = {
@@ -10,7 +9,7 @@ module.exports = {
                 rejectedStatusMailTemplateId: null
             }
         }).then(destinations => {
-            _.forEach(destinations, (d) => {
+            Promise.map(destinations, (d) => {
                 const destination = d;
                 Promise.all([
                     db.MailTemplate.create(),


### PR DESCRIPTION
Includes:
- Adding default mailTemplates to destinations in prod that does not have mailTemplates
- Catches error that happens when we try to add default admin and it's already there

Tested locally with production settings 

See [DIH-219](https://jira.capraconsulting.no/browse/DIH-219)
