### PR TITLE
Add update user endpoint with admin authorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "bluebird": "^3.4.0",
     "body-parser": "^1.15.1",
+    "composable-middleware": "^0.3.0",
     "continuation-local-storage": "^3.1.7",
     "cookie-parser": "^1.4.3",
     "cors": "^2.7.1",

--- a/src/components/auth/index.js
+++ b/src/components/auth/index.js
@@ -4,7 +4,7 @@
  */
 import jwt from 'jsonwebtoken';
 import Promise from 'bluebird';
-import { AuthenticationError } from '../errors';
+import { AuthenticationError, AuthorizationError } from '../errors';
 import config from '../../config';
 Promise.promisifyAll(jwt);
 
@@ -48,4 +48,26 @@ export function authorize(req, res, next) {
             next();
         })
         .catch(error => next(new AuthenticationError(error.message)));
+}
+
+/**
+ * verifyAdministrator - middleware to check if the current user is an administrator.
+ *
+ * @param  {Object} req  Express request object
+ * @param  {Object} res  Express response object
+ * @param  {Function} next Express next middleware function
+ */
+export function verifyAdministrator(req, res, next) {
+    let currentUser = undefined;
+
+    try {
+        currentUser = req.user;
+    } catch (error) {
+        throw new AuthenticationError();
+    }
+
+    if (!currentUser) next(new AuthenticationError());
+    if (currentUser.role !== 'ADMIN') next(new AuthorizationError());
+
+    next();
 }

--- a/src/components/auth/index.js
+++ b/src/components/auth/index.js
@@ -55,6 +55,10 @@ export function authorize(req, res, next) {
 /**
  * authorizeAdministrator - combines two middleware where the first authorizes the
  * users JWT and the second checks for administrator privileges.
+ *
+ * @param  {Object} req  Express request object
+ * @param  {Object} res  Express response object
+ * @param  {Function} next Express next middleware function
  */
 export const authorizeAdministrator =
     composableMiddleware()
@@ -67,6 +71,10 @@ export const authorizeAdministrator =
 /**
  * authorizeModerator - combines two middleware where the first authorizes the users
  * JWT and the second checks for administrator privileges or higher.
+ *
+ * @param  {Object} req  Express request object
+ * @param  {Object} res  Express response object
+ * @param  {Function} next Express next middleware function
  */
 export const authorizeModerator =
     composableMiddleware()

--- a/src/components/errors.js
+++ b/src/components/errors.js
@@ -122,6 +122,22 @@ export class AuthenticationError extends Error {
 }
 
 /**
+* AuthorizationError - Returns a 401 You are not authorized to access this resource,
+* implying that the user does not have enough premissions to complete this request.
+*
+* @param  {String} message - A message sent to the user why he/she is not authenticated
+* @return {Object}  - Error object
+*/
+export class AuthorizationError extends Error {
+    name = 'AuthorizationError';
+    status = 401;
+    constructor(message = 'You are not authorized to access this resource') {
+        super(message);
+        this.message = message;
+    }
+}
+
+/**
  * UriValidationError - Returns a 400 Invalid URI.
  * indicating that the URI the user gave was invalid.
  *

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -5,7 +5,7 @@
  */
 import db from '../models';
 import Sequelize from 'sequelize';
-import { ResourceNotFoundError, ValidationError } from '../components/errors';
+import { DatabaseError, ResourceNotFoundError, ValidationError } from '../components/errors';
 
 
 /**
@@ -41,6 +41,35 @@ export function retrieve(req, res, next) {
     .then(user => {
         if (!user) throw new ResourceNotFoundError('user');
         res.json(user);
+    })
+    .catch(next);
+}
+
+/**
+ * update - Updates a single user given ID and that the user exists.
+ *
+ * @function update
+ * @memberof module:controllers/user
+ * @param  {Object} req  Express request object
+ * @param  {Object} res  Express response object
+ * @param  {Function} next Express next middleware function
+ */
+export function update(req, res, next) {
+    db.User.findOne({
+        where: {
+            id: req.params.id
+        }
+    })
+    .then(user => {
+        if (!user) throw new ResourceNotFoundError('user');
+        return user.update(req.body);
+    })
+    .then(() => res.sendStatus(204))
+    .catch(Sequelize.ValidationError, err => {
+        throw new ValidationError(err);
+    })
+    .catch(Sequelize.DatabaseError, err => {
+        throw new DatabaseError(err);
     })
     .catch(next);
 }

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -30,11 +30,17 @@ export default function (sequelize, DataTypes) {
         },
         firstname: {
             type: DataTypes.STRING,
-            allowNull: false
+            allowNull: false,
+            validate: {
+                notEmpty: true
+            }
         },
         lastname: {
             type: DataTypes.STRING,
-            allowNull: false
+            allowNull: false,
+            validate: {
+                notEmpty: true
+            }
         },
         birth: {
             type: DataTypes.DATE

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import { authorize } from '../components/auth';
 import * as controller from '../controllers/user.controller';
 
 const router = express.Router();
@@ -6,6 +7,8 @@ const router = express.Router();
 router.get('/', controller.list);
 
 router.get('/:id', controller.retrieve);
+
+router.put('/:id', authorize, controller.update);
 
 router.post('/', controller.create);
 

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { authorize } from '../components/auth';
+import { authorize, verifyAdministrator } from '../components/auth';
 import * as controller from '../controllers/user.controller';
 
 const router = express.Router();
@@ -8,7 +8,7 @@ router.get('/', controller.list);
 
 router.get('/:id', controller.retrieve);
 
-router.put('/:id', authorize, controller.update);
+router.put('/:id', authorize, verifyAdministrator, controller.update);
 
 router.post('/', controller.create);
 

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { authorize, verifyAdministrator } from '../components/auth';
+import { authorizeAdministrator } from '../components/auth';
 import * as controller from '../controllers/user.controller';
 
 const router = express.Router();
@@ -8,7 +8,7 @@ router.get('/', controller.list);
 
 router.get('/:id', controller.retrieve);
 
-router.put('/:id', authorize, verifyAdministrator, controller.update);
+router.put('/:id', authorizeAdministrator, controller.update);
 
 router.post('/', controller.create);
 

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -6,7 +6,7 @@ const router = express.Router();
 
 router.get('/', controller.list);
 
-router.get('/:id', controller.retrieve);
+router.get('/:id', authorizeAdministrator, controller.retrieve);
 
 router.put('/:id', authorizeAdministrator, controller.update);
 

--- a/test/api/users.test.js
+++ b/test/api/users.test.js
@@ -1,4 +1,4 @@
-import { getAllElements, loadFixtures } from '../helpers';
+import { createValidJWT, getAllElements, loadFixtures } from '../helpers';
 import { describe } from 'ava-spec';
 import request from 'supertest-as-promised';
 import { updateTransport } from '../../src/components/mail';
@@ -110,5 +110,15 @@ describe.serial('User API', it => {
             .expect(400);
 
         t.is(response.body.message, 'email must be unique');
+    });
+
+    it('should update a user', async () => {
+        const user = dbObjects[0];
+        const validJwt = createValidJWT(dbObjects[1]);
+        await request(app)
+            .put(`${URI}/${user.id}`)
+            .send({ firstname: 'Alexander' })
+            .set('Authorization', `Bearer ${validJwt}`)
+            .expect(204);
     });
 });

--- a/test/api/users.test.js
+++ b/test/api/users.test.js
@@ -126,6 +126,36 @@ describe.serial('User API', it => {
             .expect(204);
     });
 
+    it('should not update a user with blank firstname', async () => {
+        const user = dbObjects[0];
+        const validJwt = createValidJWT(dbObjects[1]);
+        await request(app)
+            .put(`${URI}/${user.id}`)
+            .send({ firstname: '' })
+            .set('Authorization', `Bearer ${validJwt}`)
+            .expect(400);
+    });
+
+    it('should not update a user with blank lastname', async () => {
+        const user = dbObjects[0];
+        const validJwt = createValidJWT(dbObjects[1]);
+        await request(app)
+            .put(`${URI}/${user.id}`)
+            .send({ lastname: '' })
+            .set('Authorization', `Bearer ${validJwt}`)
+            .expect(400);
+    });
+
+    it('should not update a user with blank email', async () => {
+        const user = dbObjects[0];
+        const validJwt = createValidJWT(dbObjects[1]);
+        await request(app)
+            .put(`${URI}/${user.id}`)
+            .send({ email: '' })
+            .set('Authorization', `Bearer ${validJwt}`)
+            .expect(400);
+    });
+
     it('should not update a user when not admin', async t => {
         const user = dbObjects[1];
         const validJwt = createValidJWT(dbObjects[0]);

--- a/test/api/users.test.js
+++ b/test/api/users.test.js
@@ -42,16 +42,20 @@ describe.serial('User API', it => {
 
     it('should return a single existing user', async t => {
         const fixture = dbObjects[0];
+        const validJwt = createValidJWT(dbObjects[1]);
         const response = await request(app)
             .get(`${URI}/${fixture.id}`)
+            .set('Authorization', `Bearer ${validJwt}`)
             .expect(200);
         t.is(response.body.email, fixture.email);
     });
 
     it('should return ResourceNotFound when retrieving nonexisting user', async t => {
         const fixture = dbObjects[0];
+        const validJwt = createValidJWT(dbObjects[1]);
         const response = await request(app)
             .get(`${URI}/${fixture.id + 10000}`)
+            .set('Authorization', `Bearer ${validJwt}`)
             .expect(404);
         t.is(response.body.name, 'ResourceNotFoundError');
         t.is(response.body.message, 'Could not find resource of type user');

--- a/test/api/users.test.js
+++ b/test/api/users.test.js
@@ -121,4 +121,16 @@ describe.serial('User API', it => {
             .set('Authorization', `Bearer ${validJwt}`)
             .expect(204);
     });
+
+    it('should not update a user when not admin', async t => {
+        const user = dbObjects[1];
+        const validJwt = createValidJWT(dbObjects[0]);
+        const response = await request(app)
+            .put(`${URI}/${user.id}`)
+            .send({ firstname: 'Ada' })
+            .set('Authorization', `Bearer ${validJwt}`)
+            .expect(401);
+
+        t.is(response.body.name, 'AuthorizationError');
+    });
 });


### PR DESCRIPTION
This PR will implement the following feature:
- A brand new endpoint used for updating users.
- An authorization middleware used to check is the current user is an administrator.
- A new type of error used for authorization, not authentication. _There is a huge difference._
- Add validators for _firstname_ and _lastname_ such that they can't be blank.

[Updated doc is available on Confy](https://confluence.capraconsulting.no/display/DIH/REST+API)
See [DIH-239](https://jira.capraconsulting.no/browse/DIH-239)
