### PR TITLE
[Doppins] Upgrade dependency supertest to ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "nyc": "^7.1.0",
     "sequelize-fixtures": "^0.5.3",
     "sinon": "^1.17.4",
-    "supertest": "^1.2.0",
+    "supertest": "^2.0.0",
     "supertest-as-promised": "^3.1.0",
     "umzug": "^1.11.0"
   }


### PR DESCRIPTION
Hi!

A new version was just released of `supertest`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded supertest from `^1.2.0` to `^2.0.0`
