### PR TITLE
[Doppins] Upgrade dependency raven to ^0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "nodemailer-express-handlebars": "^2.0.0",
     "nodemailer-ses-transport": "^1.3.1",
     "pg": "^6.0.1",
-    "raven": "^0.11.0",
+    "raven": "^0.12.0",
     "sequelize": "^3.23.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven from `^0.11.0` to `^0.12.0`
