### PR TITLE
[Doppins] Upgrade dependency eslint to ^3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "^2.12.0",
+    "eslint": "^3.2.2",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `^2.12.0` to `^3.2.2`
#### Changelog:
#### Version 3.2.0
- 2438ee2 Upgrade: Update markdownlint dependency to 0.2.0 (fixes `#6781`) (`#6782`) (David Anson)
- 4fc0018 Chore: dogfooding `no-var` rule and remove `var`s (refs `#6407`) (`#6757`) (Toru Nagashima)
- b22eb5c New: `no-tabs` rule (fixes `#6079`) (`#6772`) (Gyandeep Singh)
- ddea63a Chore: Updated no-control-regex tests to cover all cases (fixes `#6438`) (`#6752`) (Efe Gürkan YALAMAN)
- 1025772 Docs: Add plugin example to disabling with comments guide (fixes `#6742`) (`#6747`) (Brandon Mills)
- 628aae4 Docs: fix inconsistent spacing inside block comment (`#6768`) (Brian Jacobel)
- 2983c32 Docs: Add options to func-names config comments (`#6748`) (Brandon Mills)
- 2f94443 Docs: fix wrong path (`#6763`) (molee1905)
- 6f3faa4 Revert "Build: Remove support for Node v5 (fixes `#6743`)" (`#6758`) (Nicholas C. Zakas)
- 99dfd1c Docs: fix grammar issue in rule-changes page (`#6761`) (Vitor Balocco)
- e825458 Fix: Rule no-unused-vars had missing period (fixes `#6738`) (`#6739`) (Brian Mock)
- 71ae64c Docs: Clarify cache file deletion (fixes `#4943`) (`#6712`) (Nicholas C. Zakas)
- 26c85dd Update: merge warnings of consecutive unreachable nodes (fixes `#6583`) (`#6729`) (Toru Nagashima)
- 106e40b Fix: Correct grammar in object-curly-newline reports (fixes `#6725`) (`#6728`) (Vitor Balocco)
- e00754c Chore: Dogfooding ES6 rules (refs `#6407`) (`#6735`) (alberto)
- 181b26a Build: Remove support for Node v5 (fixes `#6743`) (`#6744`) (alberto)
- 5320a6c Update: `no-use-before-define` false negative on for-in/of (fixes `#6699`) (`#6719`) (Toru Nagashima)
- a2090cb Fix: space-infix-ops doesn't fail for  type annotations(fixes `#5211`) (`#6723`) (Nicholas C. Zakas)
- 9c36ecf Docs: Add `@vitorbal` and `@platinumazure` to development team (Ilya Volodin)
- e09d1b8 Docs: describe all RuleTester options (fixes `#4810`, fixes `#6709`) (`#6711`) (Nicholas C. Zakas)
- a157f47 Chore: Update CLIEngine option desc (fixes `#5179`) (`#6713`) (Nicholas C. Zakas)
- a0727f9 Chore: fix `.gitignore` for vscode (refs `#6383`) (`#6720`) (Toru Nagashima)
- 75d2d43 Docs: Clarify Closure type hint expectation (fixes `#5231`) (`#6714`) (Nicholas C. Zakas)
- 95ea25a Update: Check indentation of multi-line chained properties (refs `#1801`) (`#5940`) (Rich Trott)
- e7b1e1c Docs: Edit issue/PR waiting period docs (fixes `#6009`) (`#6715`) (Nicholas C. Zakas)
- 053aa0c Update: Added 'allowSuper' option to `no-underscore-dangle` (fixes `#6355`) (`#6662`) (peteward44)
- 8929045 Build: Automatically generate rule index (refs `#2860`) (`#6658`) (Ilya Volodin)
- f916ae5 Docs: Fix multiline-ternary typos (`#6704`) (Cédric Malard)
- c64b0c2 Chore: First ES6 refactoring (refs `#6407`) (`#6570`) (Nicholas C. Zakas)
#### Version 3.1.1
- 565e584 Fix: `eslint:all` causes regression in 3.1.0 (fixes `#6687`) (`#6696`) (alberto)
- cb90359 Fix: Allow named recursive functions (fixes `#6616`) (`#6667`) (alberto)
- 3f206dd Fix: `balanced` false positive in `spaced-comment` (fixes `#6689`) (`#6692`) (Grant Snodgrass)
- 57f1676 Docs: Add missing brackets from code examples (`#6700`) (Plusb Preco)
- 124f066 Chore: Remove fixable key from multiline-ternary metadata (fixes `#6683`) (`#6688`) (Kai Cataldo)
- 9f96086 Fix: Escape control characters in XML. (fixes `#6673`) (`#6672`) (George Chung)
#### Version 3.1.0
- e8f8c6c Fix: incorrect exitCode when eslint is called with --stdin (fixes `#6677`) (`#6682`) (Steven Humphrey)
- 38639bf Update: make `no-var` fixable (fixes `#6639`) (`#6644`) (Toru Nagashima)
- dfc20e9 Fix: `no-unused-vars` false positive in loop (fixes `#6646`) (`#6649`) (Toru Nagashima)
- 2ba75d5 Update: relax outerIIFEBody definition (fixes `#6613`) (`#6653`) (Stephen E. Baker)
- 421e4bf Chore: combine multiple RegEx replaces with one (fixes `#6669`) (`#6661`) (Sakthipriyan Vairamani)
- 089ee2c Docs: fix typos,wrong path,backticks (`#6663`) (molee1905)
- ef827d2 Docs: Add another pre-commit hook to integrations (`#6666`) (David Alan Hjelle)
- a343b3c Docs: Fix option typo in no-underscore-dangle (Fixes `#6674`) (`#6675`) (Luke Page)
- 5985eb2 Chore: add internal rule that validates meta property (fixes `#6383`) (`#6608`) (Vitor Balocco)
- 4adb15f Update: Add `balanced` option to `spaced-comment` (fixes `#4133`) (`#6575`) (Annie Zhang)
- 1b13c25 Docs: fix incorrect example being mark as correct (`#6660`) (David Björklund)
- a8b4e40 Fix: Install required eslint plugin for "standard" guide (fixes `#6656`) (`#6657`) (Feross Aboukhadijeh)
- 720686b New: `endLine` and `endColumn` of the lint result. (refs `#3307`) (`#6640`) (Toru Nagashima)
- 54faa46 Docs: Small tweaks to CLI documentation (fixes `#6627`) (`#6642`) (Kevin Partington)
- e108850 Docs: Added examples and structure to `padded-blocks` (fixes `#6628`) (`#6643`) (alberto)
- 350e1c0 Docs: Typo (`#6650`) (Peter Rood)
- b837c92 Docs: Correct a term in max-len.md (fixes `#6637`) (`#6641`) (Vse Mozhet Byt)
- baeb313 Fix: Warning behavior for executeOnText (fixes `#6611`) (`#6632`) (Nicholas C. Zakas)
- e6004be Chore: Enable preferType in valid-jsdoc (refs `#5188`) (`#6634`) (Nicholas C. Zakas)
- ca323cf Fix: Use default assertion messages (fixes `#6532`) (`#6615`) (Dmitrii Abramov)
- 2bdf22c Fix: Do not throw exception if baseConfig is provided (fixes `#6605`) (`#6625`) (Kevin Partington)
- e42cacb Upgrade: mock-fs to 3.10, fixes for Node 6.3 (fixes `#6621`) (`#6624`) (Tim Schaub)
- 8a263ae New: multiline-ternary rule (fixes `#6066`) (`#6590`) (Kai Cataldo)
- e951303 Update: Adding new `key-spacing` option (fixes `#5613`) (`#5907`) (Kyle Mendes)
- 10c3e91 Docs: Remove reference from 3.0.0 migration guide (refs `#6605`) (`#6618`) (Kevin Partington)
- 5010694 Docs: Removed non-existing resource (`#6609`) (Moritz Kröger)
- 6d40d85 Docs: Note that PR requires ACCEPTED issue (refs `#6568`) (`#6604`) (Patrick McElhaney)
#### Version 3.0.1
- 27700cf Fix: `no-unused-vars` false positive around callback (fixes `#6576`) (`#6579`) (Toru Nagashima)
- 124d8a3 Docs: Pull request template (`#6568`) (Nicholas C. Zakas)
- e9a2ed9 Docs: Fix rules\id-length exceptions typos (fixes `#6397`) (`#6593`) (GramParallelo)
- a2cfa1b Fix: Make outerIIFEBody work correctly (fixes `#6585`) (`#6596`) (Nicholas C. Zakas)
- 9c451a2 Docs: Use string severity in example (`#6601`) (Kenneth Williams)
- 8308c0b Chore: remove path-is-absolute in favor of the built-in (fixes `#6598`) (`#6600`) (shinnn)
- 7a63717 Docs: Add missing pull request step (fixes `#6595`) (`#6597`) (Nicholas C. Zakas)
- de3ed84 Fix: make `no-unused-vars` ignore for-in (fixes `#2342`) (`#6126`) (Oleg Gaidarenko)
- 6ef2cbe Fix: strip Unicode BOM of config files (fixes `#6556`) (`#6580`) (Toru Nagashima)
- ee7fcfa Docs: Correct type of `outerIIFEBody` in `indent` (fixes `#6581`) (`#6584`) (alberto)
- 25fc7b7 Fix: false negative of `max-len` (fixes `#6564`) (`#6565`) (not-an-aardvark)
- f6b8452 Docs: Distinguish examples in rules under Stylistic Issues part 6 (`#6567`) (Kenneth Williams)
#### Version 3.0.0
- 66de9d8 Docs: Update installation instructions on README (`#6569`) (Nicholas C. Zakas)
- dc5b78b Breaking: Add `require-yield` rule to `eslint:recommended` (fixes `#6550`) (`#6554`) (Gyandeep Singh)
- 7988427 Fix: lib/config.js tests pass if personal config exists (fixes `#6559`) (`#6566`) (Kevin Partington)
- 4c05967 Docs: Update rule docs for new format (fixes `#5417`) (`#6551`) (Nicholas C. Zakas)
- 70da5a8 Docs: Correct link to rules page (#fixes 6553) (`#6561`) (alberto)
- e2b2030 Update: Check RegExp strings for `no-regex-spaces` (fixes `#3586`) (`#6379`) (Jackson Ray Hamilton)
- 397e51b Update: Implement outerIIFEBody for indent rule (fixes `#6259`) (`#6382`) (David Shepherd)
- 666da7c Docs: 3.0.0 migration guide (`#6521`) (Nicholas C. Zakas)
- b9bf8fb Docs: Update Governance Policy (fixes `#6452`) (`#6522`) (Nicholas C. Zakas)
- 1290657 Update: `no-unused-vars` ignores read it modifies itself (fixes `#6348`) (`#6535`) (Toru Nagashima)
- d601f6b Fix: Delete cache only when executing on files (fixes `#6459`) (`#6540`) (Kai Cataldo)
- e0d4b19 Breaking: Error thrown/printed if no config found (fixes `#5987`) (`#6538`) (Kevin Partington)
- 18663d4 Fix: false negative of `no-useless-rename` (fixes `#6502`) (`#6506`) (Toru Nagashima)
- 0a7936d Update: Add fixer for prefer-const (fixes `#6448`) (`#6486`) (Nick Heiner)
- c60341f Chore: Update index and `meta` for `"eslint:recommended"` (refs `#6403`) (`#6539`) (Mark Pedrotti)
- 73da28d Better wording for the error reported by the rule "no-else-return" `#6411` (`#6413`) (Olivier Thomann)
- e06a5b5 Update: Add fixer for arrow-parens (fixes `#4766`) (`#6501`) (madmed88)
- 5f8f3e8 Docs: Remove Box as a sponsor (`#6529`) (Nicholas C. Zakas)
- 7dfe0ad Docs: fix max-lines samples (fixes `#6516`) (`#6515`) (Dmitriy Shekhovtsov)
- fa05119 Breaking: Update eslint:recommended (fixes `#6403`) (`#6509`) (Nicholas C. Zakas)
- e96177b Docs: Add "Proposing a Rule Change" link to CONTRIBUTING.md (`#6511`) (Kevin Partington)
- bea9096 Docs: Update pull request steps (fixes `#6474`) (`#6510`) (Nicholas C. Zakas)
- 7bcf6e0 Docs: Consistent example headings & text pt3 (refs `#5446`) (`#6492`) (Guy Fraser)
- 1a328d9 Docs: Consistent example headings & text pt4 (refs `#5446`) (`#6493`) (Guy Fraser)
- ff5765e Docs: Consistent example headings & text pt2 (refs `#5446`)(`#6491`) (Guy Fraser)
- 01384fa Docs: Fixing typos (refs `#5446`)(`#6494`) (Guy Fraser)
- 4343ae8 Fix: false negative of `object-shorthand` (fixes `#6429`) (`#6434`) (Toru Nagashima)
- b7d8c7d Docs: more accurate yoda-speak (`#6497`) (Tony Lukasavage)
- 3b0ab0d Fix: add warnIgnored flag to CLIEngine.executeOnText (fixes `#6302`) (`#6305`) (Robert Levy)
- c2c6cec Docs: Mark object-shorthand as fixable. (`#6485`) (Nick Heiner)
- 5668236 Fix: Allow objectsInObjects exception when destructuring (fixes `#6469`) (`#6470`) (Adam Renklint)
- 17ac0ae Fix: `strict` rule reports a syntax error for ES2016 (fixes `#6405`) (`#6464`) (Toru Nagashima)
- 4545123 Docs: Rephrase documentation for `no-duplicate-imports` (`#6463`) (Simen Bekkhus)
- 1b133e3 Docs: improve `no-native-reassign` and specifying globals (fixes `#5358`) (`#6462`) (Toru Nagashima)
- b179373 Chore: Remove dead code in excuteOnFiles (fixes `#6467`) (`#6466`) (Andrew Hutchings)
- 18fbc4b Chore: Simplify eslint process exit code (fixes `#6368`) (`#6371`) (alberto)
- 58542e4 Breaking: Drop support for node < 4 (fixes `#4483`) (`#6401`) (alberto)
- f50657e Breaking: use default for complexity in eslint:recommended (fixes `#6021`) (`#6410`) (alberto)
- 3e690fb Fix: Exit init early if guide is chosen w/ no package.json (fixes `#6476`) (`#6478`) (Kai Cataldo)
