### PR TITLE
Add field and migration for readTerms of user

### DIFF
--- a/src/db-helpers/migrations/03082016.00.user.migration.js
+++ b/src/db-helpers/migrations/03082016.00.user.migration.js
@@ -1,0 +1,14 @@
+module.exports = {
+    up(migration, DataTypes) {
+        return migration.addColumn('users', 'readTerms', {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false,
+            allowNull: false
+        });
+    },
+
+    down(migration) {
+        return migration.removeColumn('users', 'readTerms');
+    }
+
+};

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -51,6 +51,11 @@ export default function (sequelize, DataTypes) {
             type: DataTypes.TEXT,
             defaultValue: ''
         },
+        readTerms: {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false,
+            allowNull: false
+        },
         hash: DataTypes.STRING,
         role: {
             type: DataTypes.ENUM,

--- a/test/api/users.test.js
+++ b/test/api/users.test.js
@@ -88,6 +88,20 @@ describe.serial('User API', it => {
         t.is(response.body.role, 'USER');
     });
 
+    it('should set readTerms false not given', async t => {
+        const response = await request(app)
+            .post(URI)
+            .send({
+                email: 'bojack@horseman.com',
+                firstname: 'Bojack',
+                lastname: 'Horseman'
+            })
+            .expect(201);
+
+        t.is(response.body.readTerms, false);
+    });
+
+
     it('should not add a new user without valid email', async t => {
         const response = await request(app)
             .post(URI)
@@ -112,7 +126,6 @@ describe.serial('User API', it => {
                 role: 'USER'
             })
             .expect(400);
-
         t.is(response.body.message, 'email must be unique');
     });
 


### PR DESCRIPTION
## At a glance
- Add field `readTerms` to user model
- Add migration which is tested locally
## References

See [DIH-274](https://jira.capraconsulting.no/browse/DIH-274)
