### PR TITLE
Add new fields, statuses and flow logic to trip

### DIFF
--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -38,6 +38,7 @@ exports.TRAVEL_METHODS = {
  * @property {string} CLOSED - The trip is closed, hence the user has completed this trip
  * @property {string} PRESENT - Volunteer is present at destination
  * @property {string} LEFT - Volunteer has left the destination
+ * @property {string} NOSHOW - Volunteer did not show up at location
  */
 exports.TRIP_STATUSES = {
     PENDING: 'PENDING',
@@ -46,7 +47,8 @@ exports.TRIP_STATUSES = {
     ACTIVE: 'ACTIVE',
     CLOSED: 'CLOSED',
     PRESENT: 'PRESENT',
-    LEFT: 'LEFT'
+    LEFT: 'LEFT',
+    NOSHOW: 'NO SHOW'
 };
 
 /**

--- a/src/db-helpers/migrations/04082016.00.trip.migration.js
+++ b/src/db-helpers/migrations/04082016.00.trip.migration.js
@@ -1,0 +1,31 @@
+
+module.exports = {
+
+    up(migration, DataTypes) {
+        const tableName = 'trips';
+        return [
+            migration.sequelize.query("ALTER TYPE enum_trips_status ADD VALUE 'NO SHOW'"),
+            migration.addColumn(tableName, 'dateArrived', {
+                type: DataTypes.DATE,
+                allowNull: true
+            }),
+            migration.addColumn(tableName, 'dateLeft', {
+                type: DataTypes.DATE,
+                allowNull: true
+            }),
+            migration.addColumn(tableName, 'statusComment', {
+                type: DataTypes.TEXT,
+                defaultValue: ''
+            })
+        ];
+    },
+
+    down(migration) {
+        const tableName = 'trips';
+        return [
+            migration.removeColumn(tableName, 'dateArrived'),
+            migration.removeColumn(tableName, 'dateLeft'),
+            migration.removeColumn(tableName, 'statusComment')
+        ];
+    }
+};

--- a/src/models/trip.model.js
+++ b/src/models/trip.model.js
@@ -40,7 +40,19 @@ export default function (sequelize, DataTypes) {
         flightNumber: DataTypes.STRING,
         arrivalDate: DataTypes.DATE,
         departureDate: DataTypes.DATE,
-        otherTravelInformation: DataTypes.TEXT
+        otherTravelInformation: DataTypes.TEXT,
+        statusComment: {
+            type: DataTypes.TEXT,
+            defaultValue: ''
+        },
+        dateArrived: {
+            type: DataTypes.DATE,
+            allowNull: true
+        },
+        dateLeft: {
+            type: DataTypes.DATE,
+            allowNull: true
+        }
     }, {
         classMethods: {
             associate(models) {
@@ -66,11 +78,15 @@ export default function (sequelize, DataTypes) {
                 trip => {
                     if (trip.changed('status')) {
                         if (trip.status === TRIP_STATUSES.ACCEPTED) {
-                            return trip.userActionToUser(trip.status);
+                            return trip.userActionToUser(TRIP_STATUSES.ACCEPTED);
                         }
                         if (trip.status === TRIP_STATUSES.REJECTED) {
                             return trip.userInfoToUser(trip.status);
                         }
+                    }
+                    if (trip.status === TRIP_STATUSES.ACCEPTED && trip.hasTravelInfo()) {
+                        // Reassignment because we want to change the sequelize instance
+                        trip.status = TRIP_STATUSES.ACTIVE; // eslint-disable-line
                     }
                     return Promise.resolve();
                 }
@@ -103,6 +119,14 @@ export default function (sequelize, DataTypes) {
                     if (template) user.sendDestinationInfo(destination, template.html);
                 })
                 );
+            },
+            hasTravelInfo() {
+                if (this.travelMethod === TRAVEL_METHODS.PLANE) {
+                    return this.flightNumber && this.departureAirport;
+                } else if (this.travelMethod === TRAVEL_METHODS.OTHER) {
+                    return this.otherTravelInformation;
+                }
+                return false;
             }
         }
     });


### PR DESCRIPTION
## At a glance
- Adds trip status `NO SHOW` with migration
- Adds fields `dateArrived`, `dateLeft` and `statusComment` to trip + migration
- Ensures that if a trip is `PUT` with travelInfo and with `status` `ACCEPTED`, the status is automatically set to `ACTIVE`.
## References
- See [DIH-270](https://jira.capraconsulting.no/browse/DIH-270)
- [PR for issue in webapp](https://github.com/capraconsulting/dih-webapp/issues/135)
