### PR TITLE
[Doppins] Upgrade dependency ava to ^0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/capraconsulting/dih-api#readme",
   "dependencies": {
-    "ava": "^0.15.2",
+    "ava": "^0.16.0",
     "ava-spec": "^1.0.1",
     "aws-sdk": "^2.4.12",
     "bcrypt": "^0.8.7",


### PR DESCRIPTION
Hi!

A new version was just released of `ava`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded ava from `^0.15.2` to `^0.16.0`
#### Changelog:
#### Version 0.16.0

Hope you all are having a great summer! 😎
## Highlights
- Add [`t.notRegex()`](https://github.com/avajs/ava#notregexcontents-regex-message). `https://github.com/avajs/ava/commit/c7402023d6a3a6b7a03abf2d52d948d0964683c8`
- Provide clear error message when users attempt nested or async calls to `test()`. `https://github.com/avajs/ava/commit/8edd9c2ed169909bf19a3f9229143d8fc87d5284`
- TypeScript definition improvements. `https://github.com/avajs/ava/commit/1dd6d5b9127a6850d9a03c242e677ea359d67053` `https://github.com/avajs/ava/commit/2e984380c4df2bfe5a0af2ec37a970f4001c9f53`
- Document common pitfalls (`https://github.com/avajs/ava/blob/master/docs/common-pitfalls.md`) when using AVA. `https://github.com/avajs/ava/commit/187b8b49b0f0cedbeb2ba3a833b110a72e658fa8`
- New JSPM and SystemJS recipe (`https://github.com/avajs/ava/blob/master/docs/recipes/jspm-systemjs.md`). `https://github.com/avajs/ava/commit/c3539c1701aba896bfb088ec838e60b34913168d`
## All Changes

`https://github.com/avajs/ava/compare/v0.15.2...v0.16.0`
