### PR TITLE
[Doppins] Upgrade dependency supertest-as-promised to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "sequelize-fixtures": "^0.5.3",
     "sinon": "^1.17.4",
     "supertest": "^2.0.0",
-    "supertest-as-promised": "^3.1.0",
+    "supertest-as-promised": "^4.0.0",
     "umzug": "^1.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `supertest-as-promised`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded supertest-as-promised from `^3.1.0` to `^4.0.0`
