### PR TITLE
[Doppins] Upgrade dependency nyc to ^8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "eslint-plugin-import": "^1.8.1",
     "jsdoc": "^3.4.0",
     "jsdoc-babel": "^0.2.0",
-    "nyc": "^8.1.0"
+    "nyc": "^8.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "eslint-plugin-import": "^1.8.1",
     "jsdoc": "^3.4.0",
     "jsdoc-babel": "^0.2.0",
-    "nyc": "^7.1.0"
+    "nyc": "^8.1.0"
   }
 }


### PR DESCRIPTION
Hi!

A new version was just released of `nyc`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded nyc from `^7.1.0` to `^8.1.0`
