### PR TITLE
[Doppins] Upgrade dependency babel-eslint to ^7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-core": "^6.9.1",
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^7.0.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
     "child-process-promise": "^2.0.3",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-eslint from `^6.0.4` to `^7.0.0`
