### PR TITLE
[Doppins] Upgrade dependency eslint to 3.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.2.2",
+    "eslint": "3.8.0",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.12.1",
+    "eslint": "3.12.2",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.10.2",
+    "eslint": "3.11.0",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.9.1",
+    "eslint": "3.10.0",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.12.2",
+    "eslint": "3.13.0",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.8.1",
+    "eslint": "3.9.1",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.11.0",
+    "eslint": "3.11.1",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.12.0",
+    "eslint": "3.12.1",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.13.0",
+    "eslint": "3.13.1",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.11.1",
+    "eslint": "3.12.0",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.10.1",
+    "eslint": "3.10.2",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.8.0",
+    "eslint": "3.8.1",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "esdoc": "^0.4.7",
     "esdoc-es7-plugin": "0.0.3",
-    "eslint": "3.10.0",
+    "eslint": "3.10.1",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `3.2.2` to `3.8.0`
#### Changelog:
#### Version 3.8.0
- ee60acf Chore: add integration tests for autofixing (fixes `#5909`) (`#7349`) (Teddy Katz)
- c8796e9 Update: `comma-dangle` supports trailing function commas (refs `#7101`) (`#7181`) (Toru Nagashima)
- c4abaf0 Update: `space-before-function-paren` supports async/await (refs `#7101`) (`#7180`) (Toru Nagashima)
- d0d3b28 Fix: id-length rule incorrectly firing on member access (fixes `#6475`) (`#7365`) (Burak Yiğit Kaya)
- 2729d94 Fix: Don't report setter params in class bodies as unused (fixes `#7351`) (`#7352`) (Teddy Katz)
- 0b85004 Chore: Enable prefer-template (fixes `#6407`) (`#7357`) (Kai Cataldo)
- ca1947b Chore: Update pull request template (refs eslint/tsc-meetings`#20`) (`#7359`) (Brandon Mills)
- d840afe Docs: remove broken link from no-loop-func doc (`#7342`) (Michael McDermott)
- 5266793 Update: no-useless-escape checks template literals (fixes `#7331`) (`#7332`) (Kai Cataldo)
- b08fb91 Update: add source property to LintResult object (fixes `#7098`) (`#7304`) (Vitor Balocco)
- 0db4164 Chore: run prefer-template autofixer on test files (refs `#6407`) (`#7354`) (Kai Cataldo)
- c1470b5 Update: Make the `prefer-template` fixer unescape quotes (fixes `#7330`) (`#7334`) (Teddy Katz)
- 5d08c33 Fix: Handle parentheses correctly in `yoda` fixer (fixes `#7326`) (`#7327`) (Teddy Katz)
- cd72bba New: `func-name-matching` rule (fixes `#6065`) (`#7063`) (Annie Zhang)
- 55b5146 Fix: `RuleTester` didn't support `mocha --watch` (`#7287`) (Toru Nagashima)
- f8387c1 Update: add fixer for `prefer-spread` (`#7283`) (Teddy Katz)
- 52da71e Fix: Don't require commas after rest properties (fixes `#7297`) (`#7298`) (Teddy Katz)
- 3b11d3f Chore: refactor `no-multiple-empty-lines` (`#7314`) (Teddy Katz)
- 16d495d Docs: Updating CLI overview with latest changes (`#7335`) (Kevin Partington)
- 52dfce5 Update: add fixer for `one-var-declaration-per-line` (`#7295`) (Teddy Katz)
- 0e994ae Update: Improve the error messages for `no-unused-vars` (fixes `#7282`) (`#7315`) (Teddy Katz)
- 93214aa Chore: Convert non-lib/test files to template literals (refs `#6407`) (`#7329`) (Kai Cataldo)
- 72f394d Update: Fix false negative of `no-multiple-empty-lines` (fixes `#7312`) (`#7313`) (Teddy Katz)
- 756bc5a Update: Use characters instead of code units for `max-len` (`#7299`) (Teddy Katz)
- c9a7ec5 Fix: Improving optionator configuration for --print-config (`#7206`) (Kevin Partington)
- 51bfade Fix: avoid `object-shorthand` crash with spread properties (fixes `#7305`) (`#7306`) (Teddy Katz)
- a12d1a9 Update: add fixer for `no-lonely-if` (`#7202`) (Teddy Katz)
- 1418384 Fix: Don't require semicolons before `++`/`--` (`#7252`) (Adrian Heine né Lang)
- 2ffe516 Update: add fixer for `curly` (`#7105`) (Teddy Katz)
- ac3504d Update: add functionPrototypeMethods to wrap-iife (fixes `#7212`) (`#7284`) (Eli White)
- 5e16fb4 Update: add fixer for `no-extra-bind` (`#7236`) (Teddy Katz)
#### Version 3.7.1
- 3dcae13 Fix: Use the correct location for `comma-dangle` errors (fixes `#7291`) (`#7292`) (Teddy Katz)
- cb7ba6d Fix: no-implicit-coercion should not fix ~. (fixes `#7272`) (`#7289`) (Eli White)
- ce590e2 Chore: Add additional tests for bin/eslint.js (`#7290`) (Teddy Katz)
- 8ec82ee Docs: change links of templates to raw data (`#7288`) (Toru Nagashima)
#### Version 3.7.0
- 2fee8ad Fix: object-shorthand's consistent-as-needed option (issue `#7214`) (`#7215`) (Naomi Jacobs)
- c05a19c Update: add fixer for `prefer-numeric-literals` (`#7205`) (Teddy Katz)
- 2f171f3 Update: add fixer for `no-undef-init` (`#7210`) (Teddy Katz)
- 876d747 Docs: Steps for adding new committers/TSCers (`#7221`) (Nicholas C. Zakas)
- dffb4fa Fix: `no-unused-vars` false positive (fixes `#7250`) (`#7258`) (Toru Nagashima)
- 4448cec Docs: Adding missing ES8 reference to configuring (`#7271`) (Kevin Partington)
- 332d213 Update: Ensure `indent` handles nested functions correctly (fixes `#7249`) (`#7265`) (Teddy Katz)
- c36d842 Update: add fixer for `no-useless-computed-key` (`#7207`) (Teddy Katz)
- 18376cf Update: add fixer for `lines-around-directive` (`#7217`) (Teddy Katz)
- f8e8fab Update: add fixer for `wrap-iife` (`#7196`) (Teddy Katz)
- 558b444 Docs: Add `@not-an-aardvark` to development team (`#7279`) (Ilya Volodin)
- cd1dc57 Update: Add a fixer for `dot-location` (`#7186`) (Teddy Katz)
- 89787b2 Update: for `yoda`, add a fixer (`#7199`) (Teddy Katz)
- 742ae67 Fix: avoid indent and no-mixed-spaces-and-tabs conflicts (fixes `#7248`) (`#7266`) (Teddy Katz)
- 85b8714 Fix: Use error templates even when reading from stdin (fixes `#7213`) (`#7223`) (Teddy Katz)
- 66adac1 Docs: correction in prefer-reflect docs (fixes `#7069`) (`#7150`) (Scott Stern)
- e3f95de Update: Fix `no-extra-parens` false negative (fixes `#7229`) (`#7231`) (Teddy Katz)
- 2909c19 Docs: Fix typo in object-shorthand docs (`#7267`) (Brian Donovan)
- 7bb800d Chore: add internal rule to enforce meta.docs conventions (fixes `#6954`) (`#7155`) (Vitor Balocco)
- 722c68c Docs: add code fences to the issue template (`#7254`) (Teddy Katz)
#### Version 3.6.1
- b467436 Upgrade: Upgrade Espree to 3.3.1 (`#7253`) (Ilya Volodin)
- 299a563 Build: Do not strip .md extension from absolute URLs (`#7222`) (Kai Cataldo)
- 27042d2 Chore: removed unused code related to scopeMap (`#7218`) (Yang Su)
- d154204 Chore: Lint bin/eslint.js (`#7243`) (Kevin Partington)
- 87625fa Docs: Improve eol-last examples in docs (`#7227`) (Chainarong Tangsurakit)
- de8eaa4 Docs: `class-methods-use-this`: fix option name (`#7224`) (Jordan Harband)
- 2355f8d Docs: Add Brunch plugin to integrations (`#7225`) (Aleksey Shvayka)
- a5817ae Docs: Default option from `operator-linebreak` is `after`and not always (`#7228`) (Konstantin Pschera)
#### Version 3.6.0
- 1b05d9c Update: add fixer for `strict` (fixes `#6668`) (`#7198`) (Teddy Katz)
- 0a36138 Docs: Update ecmaVersion instructions (`#7195`) (Nicholas C. Zakas)
- aaa3779 Update: Allow `space-unary-ops` to handle await expressions (`#7174`) (Teddy Katz)
- 91bf477 Update: add fixer for `prefer-template` (fixes `#6978`) (`#7165`) (Teddy Katz)
- 745343f Update: `no-extra-parens` supports async/await (refs `#7101`) (`#7178`) (Toru Nagashima)
- 8e1fee1 Fix: Handle number literals correctly in `no-whitespace-before-property` (`#7185`) (Teddy Katz)
- 462a3f7 Update: `keyword-spacing` supports async/await (refs `#7101`) (`#7179`) (Toru Nagashima)
- 709a734 Update: Allow template string in `valid-typeof` comparison (fixes `#7166`) (`#7168`) (Teddy Katz)
- f71937a Fix: Don't report async/generator callbacks in `array-callback-return` (`#7172`) (Teddy Katz)
- 461b015 Fix: Handle async functions correctly in `prefer-arrow-callback` fixer (`#7173`) (Teddy Katz)
- 7ea3e4b Fix: Handle await expressions correctly in `no-unused-expressions` (`#7175`) (Teddy Katz)
- 16bb802 Update: Ensure `arrow-parens` handles async arrow functions correctly (`#7176`) (Teddy Katz)
- 2d10657 Chore: add tests for `generator-star-spacing` and async (refs `#7101`) (`#7182`) (Toru Nagashima)
- c118d21 Update: Let `no-restricted-properties` check destructuring (fixes `#7147`) (`#7151`) (Teddy Katz)
- 9e0b068 Fix: valid-jsdoc does not throw on FieldType without value (fixes `#7184`) (`#7187`) (Kai Cataldo)
- 4b5d9b7 Docs: Update process for evaluating proposals (fixes `#7156`) (`#7183`) (Kai Cataldo)
- 95c777a Update: Make `no-restricted-properties` more flexible (fixes `#7137`) (`#7139`) (Teddy Katz)
- 0fdf23c Update: fix `quotes` rule's false negative (fixes `#7084`) (`#7141`) (Toru Nagashima)
- f2a789d Update: fix `no-unused-vars` false negative (fixes `#7124`) (`#7143`) (Toru Nagashima)
- 6148d85 Fix: Report columns for `eol-last` correctly (fixes `#7136`) (`#7149`) (kdex)
- e016384 Update: add fixer for quote-props (fixes `#6996`) (`#7095`) (Teddy Katz)
- 35f7be9 Upgrade: espree to 3.2.0, remove tests with SyntaxErrors (fixes `#7169`) (`#7170`) (Teddy Katz)
- 28ddcf8 Fix: `max-len`: `ignoreTemplateLiterals`: handle 3+ lines (fixes `#7125`) (`#7138`) (Jordan Harband)
- 660e091 Docs: Update rule descriptions (fixes `#5912`) (`#7152`) (Kenneth Williams)
- 8b3fc32 Update: Make `indent` report lines with mixed spaces/tabs (fixes `#4274`) (`#7076`) (Teddy Katz)
- b39ac2c Update: add fixer for `no-regex-spaces` (`#7113`) (Teddy Katz)
- cc80467 Docs: Update PR templates for formatting (`#7128`) (Nicholas C. Zakas)
- 76acbb5 Fix: include LogicalExpression in indent length calc  (fixes `#6731`) (`#7087`) (Alec)
- a876673 Update: no-implicit-coercion checks TemplateLiterals (fixes `#7062`) (`#7121`) (Kai Cataldo)
- 8db4f0c Chore: Enable `typeof` check for `no-undef` rule in eslint-config-eslint (`#7103`) (Teddy Katz)
- 7e8316f Docs: Update release process (`#7127`) (Nicholas C. Zakas)
- 22edd8a Update: `class-methods-use-this`: `exceptions` option (fixes `#7085`) (`#7120`) (Jordan Harband)
- afd132a Fix: line-comment-position "above" string option now works (fixes `#7100`) (`#7102`) (Kevin Partington)
- 1738b2e Chore: fix name of internal-no-invalid-meta test file (`#7142`) (Vitor Balocco)
- ac0bb62 Docs: Fixes examples for allowTemplateLiterals (fixes `#7115`) (`#7135`) (Zoe Ingram)
- bcfa3e5 Update: Add `always`/`never` option to `eol-last` (fixes `#6938`) (`#6952`) (kdex)
- 0ca26d9 Docs: Distinguish examples for space-before-blocks (`#7132`) (Timo Tijhof)
- 9a2aefb Chore: Don't require an issue reference in check-commit npm script (`#7104`) (Teddy Katz)
- c85fd84 Fix: max-statements-per-line rule to force minimum to be 1 (fixes `#7051`) (`#7092`) (Scott Stern)
- e462e47 Docs: updates category of no-restricted-properties (fixes `#7112`) (`#7118`) (Alec)
- 6ae660b Fix: Don't report comparisons of two typeof expressions (fixes `#7078`) (`#7082`) (Teddy Katz)
- 710f205 Docs: Fix typos in Issues section of Maintainer's Guide (`#7114`) (Kai Cataldo)
- 546a3ca Docs: Clarify that linter does not process configuration (fixes `#7108`) (`#7110`) (Kevin Partington)
- 0d50943 Docs: Elaborate on `guard-for-in` best practice (fixes `#7071`) (`#7094`) (Dallon Feldner)
- 58e6d76 Docs: Fix examples for no-restricted-properties (`#7099`) (not-an-aardvark)
- 6cfe519 Docs: Corrected typo in line-comment-position rule doc (`#7097`) (Alex Mercier)
- f02e52a Docs: Add fixable note to no-implicit-coercion docs (`#7096`) (Brandon Mills)
#### Version 3.5.0
- 08fa538 Update: fix false negative of `arrow-spacing` (fixes `#7079`) (`#7080`) (Toru Nagashima)
- cec65e3 Update: add fixer for no-floating-decimal (fixes `#7070`) (`#7081`) (not-an-aardvark)
- 2a3f699 Fix: Column number for no-multiple-empty-lines (fixes `#7086`) (`#7088`) (Ian VanSchooten)
- 6947299 Docs: Add info about closing accepted issues to docs (fixes `#6979`) (`#7089`) (Kai Cataldo)
- d30157a Docs: Add link to awesome-eslint in integrations page (`#7090`) (Vitor Balocco)
- 457be1b Docs: Update so issues are not required (fixes `#7015`) (`#7072`) (Nicholas C. Zakas)
- d9513b7 Fix: Allow linting of .hidden files/folders (fixes `#4828`) (`#6844`) (Ian VanSchooten)
- 6d97c18 New: `max-len`: `ignoreStrings`+`ignoreTemplateLiterals` (fixes `#5805`) (`#7049`) (Jordan Harband)
- 538d258 Update: make no-implicit-coercion support autofixing. (fixes `#7056`) (`#7061`) (Eli White)
- 883316d Update: add fixer for prefer-arrow-callback (fixes `#7002`) (`#7004`) (not-an-aardvark)
- 7502eed Update: auto-fix for `comma-style` (fixes `#6941`) (`#6957`) (Gyandeep Singh)
- 645dda5 Update: add fixer for dot-notation (fixes `#7014`) (`#7054`) (not-an-aardvark)
- 2657846 Fix: `no-console` ignores user-defined console (fixes `#7010`) (`#7058`) (Toru Nagashima)
- 656bb6e Update: add fixer for newline-before-return (fixes `#5958`) (`#7050`) (Vitor Balocco)
- 1f995c3 Fix: no-implicit-coercion string concat false positive (fixes `#7057`) (`#7060`) (Kai Cataldo)
- 6718749 Docs: Clarify that `es6` env also sets `ecmaVersion` to 6 (`#7067`) (Jérémie Astori)
- e118728 Update: add fixer for wrap-regex (fixes `#7013`) (`#7048`) (not-an-aardvark)
- f4fcd1e Update: add more `indent` options for functions (fixes `#6052`) (`#7043`) (not-an-aardvark)
- 657eee5 Update: add fixer for new-parens (fixes `#6994`) (`#7047`) (not-an-aardvark)
- ff19aa9 Update: improve `max-statements-per-line` message (fixes `#6287`) (`#7044`) (Jordan Harband)
- 3960617 New: `prefer-numeric-literals` rule (fixes `#6068`) (`#7029`) (Annie Zhang)
- fa760f9 Chore: no-regex-spaces uses internal rule message format (fixes `#7052`) (`#7053`) (Kevin Partington)
- 22c7e09 Update: no-magic-numbers false negative on reassigned vars (fixes `#4616`) (`#7028`) (not-an-aardvark)
- be29599 Update: Throw error if whitespace found in plugin name (fixes `#6854`) (`#6960`) (Jesse Ostrander)
- 4063a79 Fix: Rule message placeholders can be inside braces (fixes `#6988`) (`#7041`) (Kevin Partington)
- 52e8d9c Docs: Clean up sort-vars (`#7045`) (Matthew Dunsdon)
- 4126f12 Chore: Rule messages use internal rule message format (fixes `#6977`) (`#6989`) (Kevin Partington)
- 46cb690 New: `no-restricted-properties` rule (fixes `#3218`) (`#7017`) (Eli White)
- 00b3042 Update: Pass file path to parse function (fixes `#5344`) (`#7024`) (Annie Zhang)
- 3f13325 Docs: Add kaicataldo and JamesHenry to our teams (`#7039`) (alberto)
- 8e77f16 Update: `new-parens` false negative (fixes `#6997`) (`#6999`) (Toru Nagashima)
- 326f457 Docs: Add missing 'to' in no-restricted-modules (`#7022`) (Oskar Risberg)
- 8277357 New: `line-comment-position` rule (fixes `#6077`) (`#6953`) (alberto)
- c1f0d76 New: `lines-around-directive` rule (fixes `#6069`) (`#6998`) (Kai Cataldo)
- 61f1de0 Docs: Fix typo in no-debugger (`#7019`) (Denis Ciccale)
- 256c4a2 Fix: Allow separate mode option for multiline and align (fixes `#6691`) (`#6991`) (Annie Zhang)
- a989a7c Docs: Declaring dependency on eslint in shared config (fixes `#6617`) (`#6985`) (alberto)
- 6869c60 Docs: Fix minor typo in no-extra-parens doc (`#6992`) (Jérémie Astori)
- 28f1619 Docs: Update the example of SwitchCase (`#6981`) (fish)
#### Version 3.4.0
- c210510 Update: add fixer for no-extra-parens (fixes `#6944`) (`#6950`) (not-an-aardvark)
- ca3d448 Fix: `prefer-const` false negative about `eslintUsed` (fixes `#5837`) (`#6971`) (Toru Nagashima)
- 1153955 Docs: Draft of JSCS migration guide (refs `#5859`) (`#6942`) (Nicholas C. Zakas)
- 3e522be Fix: false negative of `indent` with `else if` statements (fixes `#6956`) (`#6965`) (not-an-aardvark)
- 2dfb290 Docs: Distinguish examples in rules under Stylistic Issues part 7 (`#6760`) (Kenneth Williams)
- 3c710c9 Fix: rename "AirBnB" => "Airbnb" init choice (fixes `#6969`) (Harrison Shoff)
- 7660b39 Fix: `object-curly-spacing` for type annotations (fixes `#6940`) (`#6945`) (Toru Nagashima)
- 21ab784 New: do not remove non visited files from cache. (fixes `#6780`) (`#6921`) (Roy Riojas)
- 3a1763c Fix: enable ``@scope`/plugin/ruleId`-style specifier (refs`#6362`) (`#6939`) (Toru Nagashima)
- d6fd064 Update: Add never option to multiline-ternary (fixes `#6751`) (`#6905`) (Kai Cataldo)
- 0d268f1 New: `symbol-description` rule (fixes `#6778`) (`#6825`) (Jarek Rencz)
- a063d4e Fix: no-cond-assign within a function expression (fixes `#6908`) (`#6909`) (Patrick McElhaney)
- 16db93a Build: Tag docs, publish release notes (fixes `#6892`) (`#6934`) (Nicholas C. Zakas)
- 0cf1d55 Chore: Fix object-shorthand errors (fixes `#6958`) (`#6959`) (Kai Cataldo)
- 8851ddd Fix: Improve pref of globbing by inheriting glob.GlobSync (fixes `#6710`) (`#6783`) (Kael Zhang)
- cf2242c Update: `requireStringLiterals` option for `valid-typeof` (fixes `#6698`) (`#6923`) (not-an-aardvark)
- 8561389 Fix: `no-trailing-spaces` wrong fixing (fixes `#6933`) (`#6937`) (Toru Nagashima)
- 6a92be5 Docs: Update semantic versioning policy (`#6935`) (alberto)
- a5189a6 New: `class-methods-use-this` rule (fixes `#5139`) (`#6881`) (Gyandeep Singh)
- 1563808 Update: add support for ecmaVersion 20xx (fixes `#6750`) (`#6907`) (Kai Cataldo)
- d8b770c Docs: Change rule descriptions for consistent casing (`#6915`) (Brandon Mills)
- c676322 Chore: Use object-shorthand batch 3 (refs `#6407`) (`#6914`) (Kai Cataldo)
#### Version 3.3.1
- a2f06be Build: optimize rule page title for small browser tabs (fixes `#6888`) (`#6904`) (Vitor Balocco)
- 02a00d6 Docs: clarify rule details for no-template-curly-in-string (`#6900`) (not-an-aardvark)
- b9b3446 Fix: sort-keys ignores destructuring patterns (fixes `#6896`) (`#6899`) (Kai Cataldo)
- 3fe3a4f Docs: Update options in `object-shorthand` (`#6898`) (Grant Snodgrass)
- cd09c96 Chore: Use object-shorthand batch 2 (refs `#6407`) (`#6897`) (Kai Cataldo)
- 2841008 Chore: Use object-shorthand batch 1 (refs `#6407`) (`#6893`) (Kai Cataldo)
#### Version 3.3.0
- 683ac56 Build: Add CI release scripts (fixes `#6884`) (`#6885`) (Nicholas C. Zakas)
- ebf8441 Update: `prefer-rest-params` relax for member accesses (fixes `#5990`) (`#6871`) (Toru Nagashima)
- df01c4f Update: Add regex support for exceptions (fixes `#5187`) (`#6883`) (Annie Zhang)
- 055742c Fix: `no-dupe-keys` type errors (fixes `#6886`) (`#6889`) (Toru Nagashima)
- e456fd3 New: `sort-keys` rule (fixes `#6076`) (`#6800`) (Toru Nagashima)
- 3e879fc Update: Rule "eqeqeq" to have more specific null handling (fixes `#6543`) (`#6849`) (Simon Sturmer)
- e8cb7f9 Chore: use eslint-plugin-node (refs `#6407`) (`#6862`) (Toru Nagashima)
- e37bbd8 Docs: Remove duplicate statement (`#6878`) (Richard Käll)
- 11395ca Fix: `no-dupe-keys` false negative (fixes `#6801`) (`#6863`) (Toru Nagashima)
- 1ecd2a3 Update: improve error message in `no-control-regex` (`#6839`) (Jordan Harband)
- d610d6c Update: make `max-lines` report the actual number of lines (fixes `#6766`) (`#6764`) (Jarek Rencz)
- b256c50 Chore: Fix glob for core js files for lint (fixes `#6870`) (`#6872`) (Gyandeep Singh)
- f8ab8f1 New: func-call-spacing rule (fixes `#6080`) (`#6749`) (Brandon Mills)
- be68f0b New: no-template-curly-in-string rule (fixes `#6186`) (`#6767`) (Jeroen Engels)
- 80789ab Chore: don't throw if rule is in old format (fixes `#6848`) (`#6850`) (Vitor Balocco)
- d47c505 Fix: `newline-after-var` false positive (fixes `#6834`) (`#6847`) (Toru Nagashima)
- bf0afcb Update: validate void operator in no-constant-condition (fixes `#5726`) (`#6837`) (Vitor Balocco)
- 5ef839e New: Add consistent and ..-as-needed to object-shorthand (fixes `#5438`) (`#5439`) (Martijn de Haan)
- 7e1bf01 Fix: update peerDependencies of airbnb option for `--init` (fixes `#6843`) (`#6846`) (Vitor Balocco)
- 8581f4f Fix: `no-invalid-this` false positive (fixes `#6824`) (`#6827`) (Toru Nagashima)
- 90f78f4 Update: add `props` option to `no-self-assign` rule (fixes `#6718`) (`#6721`) (Toru Nagashima)
- 30d71d6 Update: 'requireForBlockBody' modifier for 'arrow-parens' (fixes `#6557`) (`#6558`) (Nicolas Froidure)
- cdded07 Chore: use native `Object.assign` (refs `#6407`) (`#6832`) (Gyandeep Singh)
- 579ec49 Chore: Add link to rule change guidelines in "needs info" template (fixes `#6829`) (`#6831`) (Kevin Partington)
- 117e7aa Docs: Remove incorrect "constructor" statement from `no-new-symbol` docs (`#6830`) (Jarek Rencz)
- aef18b4 New: `no-unsafe-negation` rule (fixes `#2716`) (`#6789`) (Toru Nagashima)
- d94e945 Docs: Update Getting Started w/ Readme installation instructions (`#6823`) (Kai Cataldo)
- dfbc112 Upgrade: proxyquire to 1.7.10 (fixes `#6821`) (`#6822`) (alberto)
- 4c5e911 Chore: enable `prefer-const` and apply it to our codebase (refs `#6407`) (`#6805`) (Toru Nagashima)
- e524d16 Update: camelcase rule fix for import declarations (fixes `#6755`) (`#6784`) (Lorenzo Zottar)
- 8f3509d Update: make `eslint:all` excluding deprecated rules (fixes `#6734`) (`#6756`) (Toru Nagashima)
- 2b17459 New: `no-global-assign` rule (fixes `#6586`) (`#6746`) (alberto)
