### PR TITLE
[Doppins] Upgrade dependency jsdoc-babel to ^0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-import": "^1.8.1",
     "jsdoc": "^3.4.0",
-    "jsdoc-babel": "^0.2.0",
+    "jsdoc-babel": "^0.3.0",
     "nyc": "^7.1.0"
   }
 }


### PR DESCRIPTION
Hi!

A new version was just released of `jsdoc-babel`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded jsdoc-babel from `^0.2.0` to `^0.3.0`

